### PR TITLE
Cleanup template `environment.yml`

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,21 +2,5 @@ name: cookbook-dev
 channels:
   - conda-forge
 dependencies:
-  - cartopy
-  - jupyterlab
-  - matplotlib
-  - nc-time-axis
-  - netcdf4
-  - numpy
-  - pip
-  - pre-commit
-  - pyproj
-  - pythia-datasets
-  - python=3.8
-  - scipy
-  - ffmpeg
-  - sqlalchemy<1.4
-  - xarray
-  - pip:
-      - jupyter-book
-      - sphinx-pythia-theme
+  - jupyter-book
+  - sphinx-pythia-theme


### PR DESCRIPTION
Remove unnecessary specs in `environment.yml` for general template usage.

Discussion:
 - Do we explicitly include `pre-commit`, lint/formatters, as a "requirement" for the infrastructure we want to provide or encourage?
 - Do we explicitly include `pythia-datasets`, or otherwise document its usage and availability?
 - Looks like with @kmpaul's work, we can rely on getting the theme from conda-forge?