### PR TITLE
Switch to executing via binderbot

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,11 +15,12 @@ tags:
   packages: 
     - samplepackage
 
-# Execute the notebooks upon build
+# Execute the notebooks via binder
 execute:
-  execute_notebooks: cache
-  timeout: 600
-  allow_errors: True
+  execute_notebooks: binder
+  # execute_notebooks: cache
+  # timeout: 600
+  # allow_errors: True
 
 # Add a few extensions to help with parsing content
 parse:

--- a/_config.yml
+++ b/_config.yml
@@ -18,9 +18,6 @@ tags:
 # Execute the notebooks via binder
 execute:
   execute_notebooks: binder
-  # execute_notebooks: cache
-  # timeout: 600
-  # allow_errors: True
 
 # Add a few extensions to help with parsing content
 parse:


### PR DESCRIPTION
This is a demo of the newly implemented switch. To execute notebooks via binderbot, we simply set the field `execute_notebooks: binder` in `_config.yml`.

That's it! The reusable workflows take care of everything else.