### PR TITLE
pin jupyter_server to < 2

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,7 @@ channels:
 dependencies:
   - jupyter-book
   - jupyterlab
+  - jupyter_server<2
   - pip
   - pip:
       - sphinx-pythia-theme


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
Trying to address #100 following @jnmorley's suggestion: here we pin `jupyter_server<2` to see if that gets rid of the version conflict for `jsonschema`