### PR TITLE
Favicon Path Fix

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -36,7 +36,7 @@ parse:
 
 sphinx:
   config:
-    html_favicon: images/icons/favicon.ico
+    html_favicon: notebooks/images/icons/favicon.ico
     html_last_updated_fmt: '%-d %B %Y'
     html_theme: sphinx_pythia_theme
     html_permalinks_icon: '<i class="fas fa-link"></i>'


### PR DESCRIPTION
Super minor PR

Got a path error in the `_config.yml` for the `favicon.ico` path when building a cookbook locally. 

Updated `images/icons/favicon.ico` -> `notebooks/images/icons/favicon.ico`


