### PR TITLE
Fix broken link

### DIFF
--- a/notebooks/notebook-template.ipynb
+++ b/notebooks/notebook-template.ipynb
@@ -48,7 +48,7 @@
    "metadata": {},
    "source": [
     "## Prerequisites\n",
-    "This section was inspired by [this template](https://github.com/alan-turing-institute/the-turing-way/blob/master/book/templates/chapter-template/chapter-landing-page.md) of the wonderful [The Turing Way](https://the-turing-way.netlify.app/welcome.html) Jupyter Book.\n",
+    "This section was inspired by [this template](https://github.com/alan-turing-institute/the-turing-way/blob/master/book/templates/chapter-template/chapter-landing-page.md) of the wonderful [The Turing Way](https://the-turing-way.netlify.app) Jupyter Book.\n",
     "\n",
     "Following your overview, tell your reader what concepts, packages, or other background information they'll **need** before learning your material. Tie this explicitly with links to other pages here in Foundations or to relevant external resources. Remove this body text, then populate the Markdown table, denoted in this cell with `|` vertical brackets, below, and fill out the information following. In this table, lay out prerequisite concepts by explicitly linking to other Foundations material or external resources, or describe generally helpful concepts.\n",
     "\n",
@@ -295,7 +295,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.11.0"
   },
   "nbdime-conflicts": {
    "local_diff": [


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
Link checker flagged a broken link in the template notebook, see [here](https://github.com/ProjectPythia/cookbook-template/actions/runs/4463605301/jobs/7838983633#step:7:48)

This should fix it. 

In general we should avoid specific links like <https://the-turing-way.netlify.app/welcome.html> wherever possible, in favor of top-level links like <https://the-turing-way.netlify.app> to avoid these kinds of failures when external sites get reorganized.