### PR TITLE
Add _build to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Default JupyterBook build output dir
+_build/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
@brian-rose I haven't taken a look to confirm this wouldn't break any existing machinery yet; I'll try to go test that before getting anything in. It would be nice if this can work and we can build cookbooks and make changes to repos without having to delete+rebuild, stash, or otherwise work around `_build/` floating around.