### PR TITLE
Try setting myst flag to raise on notebook error

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -37,6 +37,7 @@ parse:
 sphinx:
   config:
     linkcheck_ignore: ["https://doi.org/*",]
+    nb_execution_raise_on_error: true  # raise exception in build if there are notebook errors
     html_favicon: notebooks/images/icons/favicon.ico
     html_last_updated_fmt: '%-d %B %Y'
     html_theme: sphinx_pythia_theme

--- a/notebooks/notebook-template.ipynb
+++ b/notebooks/notebook-template.ipynb
@@ -75,6 +75,16 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# THIS IS JUST FOR TESTING -- should raise exception\n",
+    "print(bob)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -295,7 +305,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.0"
+   "version": "3.10.8"
   },
   "nbdime-conflicts": {
    "local_diff": [

--- a/notebooks/notebook-template.ipynb
+++ b/notebooks/notebook-template.ipynb
@@ -75,16 +75,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# THIS IS JUST FOR TESTING -- should raise exception\n",
-    "print(bob)"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
Test to try to address the problem identified in https://github.com/ProjectPythia/gridding-cookbook/issues/16: that errors in notebooks should raise errors in the book build.

There is a relevant flag in myst-nb called `nb_execution_raise_on_error`. Currently it's not exposed directly through jupyter-book (https://github.com/executablebooks/jupyter-book/issues/2011) but I *think* we can set it anyway through the section in the config file
```
sphinx:
    config:
```
where we can set arbitrary sphinx options.

I put a deliberate error into the template notebook here to see if it triggers a failure.