### PR TITLE
Clean up

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: double-quote-string-fixer
 
   - repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 23.3.0
     hooks:
       - id: black
 
@@ -28,8 +28,9 @@ repos:
     rev: v2.2.0
     hooks:
       - id: seed-isort-config
+
   - repo: https://github.com/PyCQA/isort
-    rev: 5.11.4
+    rev: 5.12.0
     hooks:
       - id: isort
 
@@ -40,7 +41,7 @@ repos:
         additional_dependencies: [prettier@v2.7.1]
 
   - repo: https://github.com/nbQA-dev/nbQA
-    rev: 1.6.1
+    rev: 1.7.0
     hooks:
       - id: nbqa-black
         additional_dependencies: [black]

--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ This Project Pythia Cookbook covers ... (replace `...` with the main subject of 
 
 ## Running the Notebooks
 
-You can either run the notebook using [Binder](https://mybinder.org/) or on your local machine.
+You can either run the notebook using [Binder](https://binder.projectpythia.org/) or on your local machine.
 
 ### Running on Binder
 
 The simplest way to interact with a Jupyter Notebook is through
-[Binder](https://mybinder.org/), which enables the execution of a
+[Binder](https://binder.projectpythia.org/), which enables the execution of a
 [Jupyter Book](https://jupyterbook.org) in the cloud. The details of how this works are not
 important for now. All you need to know is how to launch a Pythia
 Cookbooks chapter via Binder. Simply navigate your mouse to

--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@ title: Project Pythia Cookbook Template
 author: the <a href="https://projectpythia.org/">Project Pythia</a> Community
 logo: notebooks/images/logos/pythia_logo-white-rtext.svg
 email: projectpythia@ucar.edu
-copyright: "2022"
+copyright: "2023"
 
 description: A sample cookbook description.
 thumbnail: thumbnail.png
@@ -19,11 +19,11 @@ execute:
   # To execute notebooks via a binder instead, replace 'cache' with 'binder'
   execute_notebooks: cache
   timeout: 600
-  allow_errors: False # cells with expected failures must set the `raises-exception` cell tag
+  allow_errors: False  # cells with expected failures must set the `raises-exception` cell tag
 
 # Add a few extensions to help with parsing content
 parse:
-  myst_enable_extensions: # default extensions to enable in the myst parser. See https://myst-parser.readthedocs.io/en/latest/using/syntax-optional.html
+  myst_enable_extensions:  # default extensions to enable in the myst parser. See https://myst-parser.readthedocs.io/en/latest/using/syntax-optional.html
     - amsmath
     - colon_fence
     - deflist
@@ -36,16 +36,16 @@ parse:
 
 sphinx:
   config:
-    linkcheck_ignore: ["https://doi.org/*",]
-    nb_execution_raise_on_error: true  # raise exception in build if there are notebook errors
+    linkcheck_ignore: ["https://doi.org/*",]  # don't run link checker on DOI links since they are immutable
+    nb_execution_raise_on_error: true  # raise exception in build if there are notebook errors (this flag is ignored if building on binder)
     html_favicon: notebooks/images/icons/favicon.ico
     html_last_updated_fmt: '%-d %B %Y'
     html_theme: sphinx_pythia_theme
     html_permalinks_icon: '<i class="fas fa-link"></i>'
     html_theme_options:
       home_page_in_toc: true
-      repository_url: https://github.com/ProjectPythia/cookbook-template/ # Online location of your book
-      repository_branch: main # Which branch of the repository should be used when creating links (optional)
+      repository_url: https://github.com/ProjectPythia/cookbook-template/  # Online location of your book
+      repository_branch: main  # Which branch of the repository should be used when creating links (optional)
       use_issues_button: true
       use_repository_button: true
       use_edit_page_button: true

--- a/_config.yml
+++ b/_config.yml
@@ -16,14 +16,14 @@ tags:
     - samplepackage
 
 execute:
-  # To execute notebooks via a binder instead, replace 'cache' with 'binder'
+  # To execute notebooks via a Binder instead, replace 'cache' with 'binder'
   execute_notebooks: cache
   timeout: 600
-  allow_errors: False  # cells with expected failures must set the `raises-exception` cell tag
+  allow_errors: False # cells with expected failures must set the `raises-exception` cell tag
 
 # Add a few extensions to help with parsing content
 parse:
-  myst_enable_extensions:  # default extensions to enable in the myst parser. See https://myst-parser.readthedocs.io/en/latest/using/syntax-optional.html
+  myst_enable_extensions: # default extensions to enable in the myst parser. See https://myst-parser.readthedocs.io/en/latest/using/syntax-optional.html
     - amsmath
     - colon_fence
     - deflist
@@ -36,16 +36,16 @@ parse:
 
 sphinx:
   config:
-    linkcheck_ignore: ["https://doi.org/*",]  # don't run link checker on DOI links since they are immutable
-    nb_execution_raise_on_error: true  # raise exception in build if there are notebook errors (this flag is ignored if building on binder)
+    linkcheck_ignore: ["https://doi.org/*"] # don't run link checker on DOI links since they are immutable
+    nb_execution_raise_on_error: true # raise exception in build if there are notebook errors (this flag is ignored if building on binder)
     html_favicon: notebooks/images/icons/favicon.ico
-    html_last_updated_fmt: '%-d %B %Y'
+    html_last_updated_fmt: "%-d %B %Y"
     html_theme: sphinx_pythia_theme
     html_permalinks_icon: '<i class="fas fa-link"></i>'
     html_theme_options:
       home_page_in_toc: true
-      repository_url: https://github.com/ProjectPythia/cookbook-template/  # Online location of your book
-      repository_branch: main  # Which branch of the repository should be used when creating links (optional)
+      repository_url: https://github.com/ProjectPythia/cookbook-template/ # Online location of your book
+      repository_branch: main # Which branch of the repository should be used when creating links (optional)
       use_issues_button: true
       use_repository_button: true
       use_edit_page_button: true


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
A bunch of clean-up to the Template prior to the 2023 hackathon:

- Point all Binder links to the new Pythia binder at https://binder.projectpythia.org
- Updates to pre-commit hooks
- Formatting fixes from running pre-commit locally
- Update copyright year
- Add a few more helpful comments in the _config file

To address #119 I plan to switch on the pre-commit.ci service for this repo to keep this stuff up to date in the template, but leave it as completely optional for individual cookbooks.