### PR TITLE
GitHub action to auto update all links that point to cookbook-template GH repo to point to real cookbook

### DIFF
--- a/.github/workflows/trigger-replace-links.yaml
+++ b/.github/workflows/trigger-replace-links.yaml
@@ -1,0 +1,31 @@
+name: trigger-replace-links
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Find and Replace Repository Name
+        uses: jacobtomlinson/gha-find-replace@v3
+        with:
+          find: "ProjectPythia/cookbook-template"
+          replace: "${{ github.repository_owner }}/${{ github.event.repository.name }}"
+          regex: false
+          exclude: ".github/workflows/trigger-replace-links.yml"
+
+      - name: Find and Replace Repository ID
+        uses: jacobtomlinson/gha-find-replace@v3
+        with:
+          find: "475509405"
+          replace: "${{ github.repository_id}}"
+          regex: false
+          exclude: ".github/workflows/trigger-replace-links.yml"
+
+      - name: Push changes
+        uses: stefanzweifel/git-auto-commit-action@v4


### PR DESCRIPTION
This looks for the `cookbook-template` and the repo ID number and replaces them with the new repo name and ID number. This has affects in a few files reducing the burden of the cookbook creator to track down all of these places that need to be changed.

See this work on a dummy cookbook here: https://github.com/jukent/draft-cookbook/commit/d4c08cdd1ed3ca2589644de7086673948fcde622#diff-ecec67b0e1d7e17a83587c6d27b6baaaa133f42482b07bd3685c77f34b62d883