### PR TITLE
Test building on binder with altered environment file

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@ copyright: "2023"
 
 execute:
   # To execute notebooks via a Binder instead, replace 'cache' with 'binder'
-  execute_notebooks: cache
+  execute_notebooks: binder
   timeout: 600
   allow_errors: False # cells with expected failures must set the `raises-exception` cell tag
 

--- a/environment.yml
+++ b/environment.yml
@@ -5,6 +5,7 @@ dependencies:
   - jupyter-book
   - jupyterlab
   - jupyter_server
+  - numpy
   - pip
   - pip:
       - sphinx-pythia-theme

--- a/notebooks/notebook-template.ipynb
+++ b/notebooks/notebook-template.ipynb
@@ -88,7 +88,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import sys"
+    "import sys\n",
+    "\n",
+    "import numpy"
    ]
   },
   {
@@ -281,7 +283,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.9.6 64-bit",
    "language": "python",
    "name": "python3"
   },
@@ -295,7 +297,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.9.6"
   },
   "nbdime-conflicts": {
    "local_diff": [
@@ -351,7 +353,12 @@
     }
    ]
   },
-  "toc-autonumbering": false
+  "toc-autonumbering": false,
+  "vscode": {
+   "interpreter": {
+    "hash": "31f2aee4e71d21fbe5cf8b01ff0e069b9275f58929596ceb00d14d90e3e16cd6"
+   }
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
I think the logic in the `build-book.yaml` workflow for dealing with changes in the environment file when building on binder is broken. Testing it here. I expect the build to fail.