### PR TITLE
Ignore zenodo badge links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -27,7 +27,7 @@ parse:
 
 sphinx:
   config:
-    linkcheck_ignore: ["https://doi.org/*"] # don't run link checker on DOI links since they are immutable
+    linkcheck_ignore: ["https://doi.org/*", "https://zenodo.org/badge/*"] # don't run link checker on DOI links since they are immutable
     nb_execution_raise_on_error: true # raise exception in build if there are notebook errors (this flag is ignored if building on binder)
     html_favicon: notebooks/images/icons/favicon.ico
     html_last_updated_fmt: "%-d %B %Y"


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
This PR flags the link-checker to ignore links `https://zenodo.org/badge/*`

This will resolve the problem of new Cookbooks starting out life with built-in link checker failures until their "first release" when the Zenodo DOI badge becomes valid.

I don't think there's much danger in not checking these links.