### PR TITLE
Publish nightly build to GitHub Pages

### DIFF
--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -12,6 +12,10 @@ jobs:
     with:
       environment_name: cookbook-dev
 
+  deploy:  # publish the built book on GitHub Pages
+    needs: build
+    uses: ProjectPythia/cookbook-actions/.github/workflows/deploy-book.yaml@main
+
   link-check:
     if: ${{ github.repository_owner == 'ProjectPythia' }}
     uses: ProjectPythia/cookbook-actions/.github/workflows/link-checker.yaml@main


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
This addresses https://github.com/ProjectPythia/cookbook-actions/issues/62 by adding the feature to publish the result of the nightly build to GitHub Pages so the gallery content is always fresh.

Per discussion at today's IWG, we should keep this in draft and not merge until we've had some further discussion about our desired default behavior.

Note that this change needs to be in the template, rather than in the reusable workflows. So we would need to manually repeat this modification in any existing cookbook repos for which we want to publish nightly.