### PR TITLE
Add .nfs* to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Ephemeral .nfs files
+.nfs*


### PR DESCRIPTION
Motivated by current experiences with students in my fall semester class who are creating cookbooks on NFS-served directories, this PR adds a line for any files beginning with `.nfs` to the `.gitignore` file, to avoid any inadvertant adds/commits which include these ephemeral files.
