### PR TITLE
Simplify environment by removing jupyter_server

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,5 +4,4 @@ channels:
 dependencies:
   - jupyter-book
   - jupyterlab
-  - jupyter_server
   - sphinx-pythia-theme


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
I don't think there's any need to explicitly include `jupyter_server` in the environment file. It's a Jupyter dependency and best to let conda/mamba sort it out and keep our env file as clean as possible.