### PR TITLE
Remove prettier from pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,12 +34,6 @@ repos:
     hooks:
       - id: isort
 
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.1.0
-    hooks:
-      - id: prettier
-        additional_dependencies: [prettier@v2.7.1]
-
   - repo: https://github.com/nbQA-dev/nbQA
     rev: 1.7.1
     hooks:


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
As suggested by @dopplershift, due to the continued aggravation of pre-commit opening PRs that include pre-release alpha versions of prettier, this PR just removes prettier entirely from our pre-commit config.