### PR TITLE
Update author links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This Project Pythia Cookbook covers ... (replace `...` with the main subject of 
 
 ## Authors
 
-[First Author](@first-author), [Second Author](@second-author), etc. _Acknowledge primary content authors here_
+[First Author](https://github.com/first-author), [Second Author](https://github.com/second-author), etc. _Acknowledge primary content authors here_
 
 ### Contributors
 


### PR DESCRIPTION
This is a small change to the README to show that GitHub profile links in the author section need to be full links (just having @ plus the name doesn't work). I've seen this a few times in submitted Cookbooks.
