### PR TITLE
Add link to cookbook guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 [![Binder](https://binder.projectpythia.org/badge_logo.svg)](https://binder.projectpythia.org/v2/gh/ProjectPythia/cookbook-template/main?labpath=notebooks)
 [![DOI](https://zenodo.org/badge/475509405.svg)](https://zenodo.org/badge/latestdoi/475509405)
 
+_See the [Cookbook Contributor's Guide](https://projectpythia.org/cookbook-guide) for step-by-step instructions on how to create your new Cookbook and get it hosted on the [Pythia Cookbook Gallery](https://cookbooks.projectpythia.org)!_
+
 This Project Pythia Cookbook covers ... (replace `...` with the main subject of your cookbook ... e.g., _working with radar data in Python_)
 
 ## Motivation


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
This PR puts a prominent link to the Cookbook guide at the top of the landing page of the template so it's easy for authors to find.

Note that the link itself is currently broken due to an issue on the portal site (https://github.com/ProjectPythia/projectpythia.github.io/issues/517, https://github.com/ProjectPythia/projectpythia.github.io/pull/519).