### PR TITLE
Add improved support for git and GitHub within JupyterLab

### DIFF
--- a/postBuild
+++ b/postBuild
@@ -1,0 +1,4 @@
+set -ex
+
+# Add support for developing with git and GitHub
+conda install -c conda-forge jupyterlab-git gh-scoped-creds


### PR DESCRIPTION
To support git (using the JupyterLab git extension) and GitHub (through gh-scoped-creds), I propose using the postBuild feature of repo2docker to add these additional packages. This means that the environment.yml file remains untouched while adding in these two-packages as 'standard' cookbooks.

